### PR TITLE
disabled debug logs for python

### DIFF
--- a/cli/sawtooth_cli/main.py
+++ b/cli/sawtooth_cli/main.py
@@ -80,7 +80,7 @@ def create_console_handler(verbose_level):
 
 def setup_loggers(verbose_level):
     logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.INFO)
     logger.addHandler(create_console_handler(verbose_level))
 
 

--- a/cli/sawtooth_cli/sawadm.py
+++ b/cli/sawtooth_cli/sawadm.py
@@ -118,7 +118,7 @@ def create_console_handler(verbose_level):
 
 def setup_loggers(verbose_level):
     logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.INFO)
     logger.addHandler(create_console_handler(verbose_level))
 
 

--- a/cli/sawtooth_cli/sawnet.py
+++ b/cli/sawtooth_cli/sawnet.py
@@ -122,7 +122,7 @@ def create_console_handler(verbose_level):
 
 def setup_loggers(verbose_level):
     logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.INFO)
     logger.addHandler(create_console_handler(verbose_level))
 
 

--- a/cli/sawtooth_cli/sawset.py
+++ b/cli/sawtooth_cli/sawset.py
@@ -438,7 +438,7 @@ def create_console_handler(verbose_level):
 
 def setup_loggers(verbose_level):
     logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.INFO)
     logger.addHandler(create_console_handler(verbose_level))
 
 

--- a/families/battleship/sawtooth_battleship/battleship_cli.py
+++ b/families/battleship/sawtooth_battleship/battleship_cli.py
@@ -65,7 +65,7 @@ def create_console_handler(verbose_level):
 
 def setup_loggers(verbose_level):
     logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.INFO)
     logger.addHandler(create_console_handler(verbose_level))
 
 

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/intkey_cli.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/intkey_cli.py
@@ -74,7 +74,7 @@ def create_console_handler(verbose_level):
 
 def setup_loggers(verbose_level):
     logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.INFO)
     logger.addHandler(create_console_handler(verbose_level))
 
 

--- a/sdk/examples/noop_python/sawtooth_noop/client_cli/main.py
+++ b/sdk/examples/noop_python/sawtooth_noop/client_cli/main.py
@@ -56,7 +56,7 @@ def create_console_handler(verbose_level):
 
 def setup_loggers(verbose_level):
     logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.INFO)
     logger.addHandler(create_console_handler(verbose_level))
 
 

--- a/sdk/examples/xo_python/sawtooth_xo/xo_cli.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_cli.py
@@ -64,7 +64,7 @@ def create_console_handler(verbose_level):
 
 def setup_loggers(verbose_level):
     logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.INFO)
     logger.addHandler(create_console_handler(verbose_level))
 
 

--- a/sdk/python/sawtooth_sdk/processor/log.py
+++ b/sdk/python/sawtooth_sdk/processor/log.py
@@ -53,14 +53,14 @@ def create_console_handler(verbose_level):
     return clog
 
 
-def init_console_logging(verbose_level=2):
+def init_console_logging(verbose_level=1):
     """
     Set up the console logging for a transaction processor.
     Args:
         verbose_level (int): The log level that the console should print out
     """
     logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.INFO)
     logger.addHandler(create_console_handler(verbose_level))
 
 
@@ -76,12 +76,6 @@ def log_configuration(log_config=None, log_dir=None, name=None):
         logging.config.dictConfig(log_config)
     else:
         log_filename = os.path.join(log_dir, name)
-        debug_handler = logging.FileHandler(log_filename + "-debug.log")
-        debug_handler.setFormatter(logging.Formatter(
-            '[%(asctime)s.%(msecs)03d [%(threadName)s] %(module)s'
-            ' %(levelname)s] %(message)s', "%H:%M:%S"))
-        debug_handler.setLevel(logging.DEBUG)
-
         error_handler = logging.FileHandler(log_filename + "-error.log")
         error_handler.setFormatter(logging.Formatter(
             '[%(asctime)s.%(msecs)03d [%(threadName)s] %(module)s'
@@ -89,4 +83,3 @@ def log_configuration(log_config=None, log_dir=None, name=None):
         error_handler.setLevel(logging.ERROR)
 
         logging.getLogger().addHandler(error_handler)
-        logging.getLogger().addHandler(debug_handler)

--- a/validator/sawtooth_validator/server/log.py
+++ b/validator/sawtooth_validator/server/log.py
@@ -59,9 +59,9 @@ def create_console_handler(verbose_level):
     return clog
 
 
-def init_console_logging(verbose_level=2, capture_std_output=False):
+def init_console_logging(verbose_level=1, capture_std_output=False):
     logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.INFO)
 
     logger.addHandler(create_console_handler(verbose_level))
 
@@ -75,11 +75,6 @@ def log_configuration(log_config=None, log_dir=None, name=None):
         logging.config.dictConfig(log_config)
     else:
         log_filename = os.path.join(log_dir, name)
-        debug_handler = logging.FileHandler(log_filename + "-debug.log")
-        debug_handler.setFormatter(logging.Formatter(
-            '[%(asctime)s.%(msecs)03d [%(threadName)s] %(module)s'
-            ' %(levelname)s] %(message)s', "%H:%M:%S"))
-        debug_handler.setLevel(logging.DEBUG)
 
         error_handler = logging.FileHandler(log_filename + "-error.log")
         error_handler.setFormatter(logging.Formatter(
@@ -88,4 +83,3 @@ def log_configuration(log_config=None, log_dir=None, name=None):
         error_handler.setLevel(logging.ERROR)
 
         logging.getLogger().addHandler(error_handler)
-        logging.getLogger().addHandler(debug_handler)


### PR DESCRIPTION
Debug log messages has been disabled in Sawtooth Core Python files. Debug messages are not displayed when we start the services and also debug log file will not be created for the respective services

Signed-off-by: sandeeplandt <sandeepx.hs@intel.com>